### PR TITLE
Update libs.versions.toml

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ coil = "2.7.0"
 leakcanary = "3.0-alpha-8"
 junit = "4.13.2"
 ksp = "2.0.21-1.0.27"
-spotless = "6.25.0"
+spotless = "7.0.0.BETA3"
 moshi = "1.15.1"
 
 [libraries]


### PR DESCRIPTION
This pull request updates the version of the `spotless` library in the `gradle/libs.versions.toml` file.

* [`gradle/libs.versions.toml`](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL28-R28): Updated `spotless` from version `6.25.0` to `7.0.0.BETA3`.